### PR TITLE
Temporary fix for scPDSI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,3 +63,4 @@ Suggests:
     rmarkdown,
     scPDSI
 VignetteBuilder: knitr
+Remotes: Sibada/scPDSI


### PR DESCRIPTION
The scPDSI package is currently unavailable from CRAN. So this at least allows installation.